### PR TITLE
Wrap default arguments using templates to compile with older g++ compilers

### DIFF
--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -654,7 +654,7 @@ class TypeParameterizedTest {
   static bool Register(const char* prefix, const CodeLocation& code_location,
                        const char* case_name, const char* test_names, int index,
                        const std::vector<std::string>& type_names =
-                           GenerateNames<DefaultNameGenerator, Types>()) {
+                           (GenerateNames<DefaultNameGenerator, Types>())) {
     typedef typename Types::Head Type;
     typedef Fixture<Type> FixtureClass;
     typedef typename GTEST_BIND_(TestSel, Type) TestClass;
@@ -706,7 +706,7 @@ class TypeParameterizedTestCase {
                        const TypedTestCasePState* state, const char* case_name,
                        const char* test_names,
                        const std::vector<std::string>& type_names =
-                           GenerateNames<DefaultNameGenerator, Types>()) {
+                           (GenerateNames<DefaultNameGenerator, Types>())) {
     std::string test_name = StripTrailingSpaces(
         GetPrefixUntilComma(test_names));
     if (!state->TestExists(test_name)) {


### PR DESCRIPTION
Older g++ compilers (e.g. 3.4.2) don't like the way default arguments are
initialised with templates. The fix is to wrap the template invocation within
brackets.